### PR TITLE
Corrected port number

### DIFF
--- a/sls.conf
+++ b/sls.conf
@@ -12,7 +12,7 @@ srt {                #SRT
     #vod  file name: /tmp/mov/sls/$listen/$domain_publisher/$app_publisher/$stream_name/vod.m3u8
 
     server {
-        listen 1935;
+        listen 2935;
         latency 200; #ms
 
         domain_player output;


### PR DESCRIPTION
Port number was originally 2935 in first version of docker so have returned it to this as 1935 is the default for rtmp with nginx.